### PR TITLE
Add Album detail view

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -2,6 +2,9 @@
 <project version="4">
   <component name="deploymentTargetDropDown">
     <value>
+      <entry key="TestArtists">
+        <State />
+      </entry>
       <entry key="app">
         <State />
       </entry>

--- a/app/src/main/java/com/vinyl/app/activities/AlbumDetailActivity.kt
+++ b/app/src/main/java/com/vinyl/app/activities/AlbumDetailActivity.kt
@@ -1,21 +1,25 @@
 package com.vinyl.app.activities
 
 import android.os.Bundle
-import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
 import com.vinyl.app.R
+import com.vinyl.app.fragments.AlbumDetailFragment
 
 class AlbumDetailActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
         setContentView(R.layout.activity_album_detail)
-        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
-            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
-            insets
+
+        val albumId = intent.getStringExtra("albumId")
+
+        if (savedInstanceState == null && albumId != null) {
+            supportFragmentManager.beginTransaction()
+                .replace(R.id.fragment_container, AlbumDetailFragment().apply {
+                    arguments = Bundle().apply {
+                        putString("albumId", albumId)
+                    }
+                })
+                .commit()
         }
     }
 }

--- a/app/src/main/java/com/vinyl/app/adapters/AlbumCatalogAdapter.kt
+++ b/app/src/main/java/com/vinyl/app/adapters/AlbumCatalogAdapter.kt
@@ -6,9 +6,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.vinyl.app.databinding.AlbumCatalogBinding
 import com.vinyl.app.pojo.Album
-
-class AlbumCatalogAdapter:RecyclerView.Adapter<AlbumCatalogAdapter.AlbumCatalogViewHolder>() {
-
+class AlbumCatalogAdapter(private val onAlbumClick: (Album) -> Unit) : RecyclerView.Adapter<AlbumCatalogAdapter.AlbumCatalogViewHolder>() {
 
     private var albumList = ArrayList<Album>()
 
@@ -18,22 +16,27 @@ class AlbumCatalogAdapter:RecyclerView.Adapter<AlbumCatalogAdapter.AlbumCatalogV
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AlbumCatalogViewHolder {
-        return AlbumCatalogViewHolder(AlbumCatalogBinding.inflate(LayoutInflater.from(parent.context), parent, false))
+        val binding = AlbumCatalogBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return AlbumCatalogViewHolder(binding)
     }
 
     override fun onBindViewHolder(holder: AlbumCatalogViewHolder, position: Int) {
-        Glide.with(holder.itemView)
-            .load(albumList[position].cover)
-            .into(holder.binding.albumImg)
-        holder.binding.albumNameTv.text = albumList[position].name
+        val album = albumList[position]
+        with(holder.binding) {
+            Glide.with(holder.itemView.context)
+                .load(album.cover)
+                .into(albumImg)
+            albumNameTv.text = album.name
+
+            root.setOnClickListener {
+                onAlbumClick(album)
+            }
+        }
     }
 
     override fun getItemCount(): Int {
         return albumList.size
     }
 
-
-
-    class AlbumCatalogViewHolder(var binding: AlbumCatalogBinding):RecyclerView.ViewHolder(binding.root)
-
+    class AlbumCatalogViewHolder(var binding: AlbumCatalogBinding): RecyclerView.ViewHolder(binding.root)
 }

--- a/app/src/main/java/com/vinyl/app/fragments/AlbumDetailFragment.kt
+++ b/app/src/main/java/com/vinyl/app/fragments/AlbumDetailFragment.kt
@@ -1,0 +1,65 @@
+package com.vinyl.app.fragments
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.ViewModelProvider
+import com.bumptech.glide.Glide
+import com.vinyl.app.R
+import com.vinyl.app.databinding.FragmentAlbumDetailBinding
+import com.vinyl.app.pojo.Album
+import com.vinyl.app.viewmodel.AlbumViewModel
+class AlbumDetailFragment : Fragment() {
+    private lateinit var viewModel: AlbumViewModel
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_album_detail, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        viewModel = ViewModelProvider(this).get(AlbumViewModel::class.java)
+
+        val albumId = arguments?.getString("albumId") ?: return
+        viewModel.getAlbum(albumId)
+
+        viewModel.observeAlbumLiveData().observe(viewLifecycleOwner) { album ->
+            updateUI(view, album)
+        }
+    }
+
+    private fun updateUI(view: View, album: Album) {
+        val albumName: TextView = view.findViewById(R.id.albumName)
+        val albumGenre: TextView = view.findViewById(R.id.albumGenre)
+        val albumDescription: TextView = view.findViewById(R.id.albumDescription)
+        val albumCover: ImageView = view.findViewById(R.id.albumCover)
+        val tracksLayout: LinearLayout = view.findViewById(R.id.tracksLayout)
+
+        albumName.text = album.name
+        albumGenre.text = album.genre
+        albumDescription.text = album.description
+
+        Glide.with(this).load(album.cover).into(albumCover)
+
+        tracksLayout.removeAllViews()
+
+        album.tracks?.forEach { track ->
+            val trackView = LayoutInflater.from(context).inflate(R.layout.track_item, tracksLayout, false)
+            val trackName: TextView = trackView.findViewById(R.id.trackName)
+            val trackDuration: TextView = trackView.findViewById(R.id.trackDuration)
+            trackName.text = track.name
+            trackDuration.text = track.duration
+            tracksLayout.addView(trackView)
+        }
+    }
+}

--- a/app/src/main/java/com/vinyl/app/fragments/HomeFragment.kt
+++ b/app/src/main/java/com/vinyl/app/fragments/HomeFragment.kt
@@ -9,6 +9,7 @@ import android.view.ViewGroup
 import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.GridLayoutManager
 import com.bumptech.glide.Glide
+import com.vinyl.app.activities.AlbumDetailActivity
 import com.vinyl.app.activities.MusicianListActivity
 import com.vinyl.app.adapters.AlbumCatalogAdapter
 import com.vinyl.app.databinding.FragmentHomeBinding
@@ -24,7 +25,6 @@ class HomeFragment : Fragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         homeMVVM = ViewModelProviders.of(this).get(HomeViewModel::class.java)
-        albumCatalogAdapter = AlbumCatalogAdapter()
 
     }
 
@@ -68,8 +68,15 @@ class HomeFragment : Fragment() {
         }
     }
 
+    private fun onAlbumButtonClick() {
+        binding.artistsButton.setOnClickListener {
+            val intent = Intent(activity, MusicianListActivity::class.java)
+            startActivity(intent)
+        }
+    }
+
     private fun onCollectorButtonClick() {
-        
+
     }
 
     // FUNCION FOR TESTING
@@ -180,11 +187,15 @@ class HomeFragment : Fragment() {
     }
 
     private fun prepareAlbumListRecyclerView() {
+        albumCatalogAdapter = AlbumCatalogAdapter { album ->
+            val intent = Intent(activity, AlbumDetailActivity::class.java).apply {
+                putExtra("albumId", album.id)
+            }
+            startActivity(intent)
+        }
         binding.recViewAlbums.apply {
-            layoutManager = GridLayoutManager(activity,2,GridLayoutManager.VERTICAL,false)
+            layoutManager = GridLayoutManager(activity, 2, GridLayoutManager.VERTICAL, false)
             adapter = albumCatalogAdapter
-
-
         }
     }
 

--- a/app/src/main/java/com/vinyl/app/fragments/MusicianListFragment.kt
+++ b/app/src/main/java/com/vinyl/app/fragments/MusicianListFragment.kt
@@ -34,8 +34,6 @@ class MusicianListFragment : Fragment() {
         const val MUSICIAN_BIRTHDATE = "com.vinyl.app.fragments.birthdate"
         const val MUSICIAN_DESCRIPTION = "com.vinyl.app.fragments.description"
         const val MUSICIAN_IMAGE = "com.vinyl.app.fragments.image"
-
-
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/vinyl/app/pojo/Album.kt
+++ b/app/src/main/java/com/vinyl/app/pojo/Album.kt
@@ -7,5 +7,6 @@ data class Album(
     val genre: String,
     val name: String,
     val recordLabel: String,
-    val releaseDate: String
+    val releaseDate: String,
+    val tracks: List<Track> = emptyList()
 )

--- a/app/src/main/java/com/vinyl/app/pojo/Track.kt
+++ b/app/src/main/java/com/vinyl/app/pojo/Track.kt
@@ -1,0 +1,7 @@
+package com.vinyl.app.pojo
+
+data class Track(
+    val id: Int,
+    val name: String,
+    val duration: String
+)

--- a/app/src/main/java/com/vinyl/app/retrofit/VinylApi.kt
+++ b/app/src/main/java/com/vinyl/app/retrofit/VinylApi.kt
@@ -16,4 +16,7 @@ interface VinylApi {
 
     @GET("musicians/{id}")
     fun getMusician(@Path("id") id:String):Call<Musician>
+
+    @GET("albums/{id}")
+    fun getAlbum(@Path("id") id:String):Call<Album>
 }

--- a/app/src/main/java/com/vinyl/app/viewmodel/AlbumViewModel.kt
+++ b/app/src/main/java/com/vinyl/app/viewmodel/AlbumViewModel.kt
@@ -1,0 +1,41 @@
+package com.vinyl.app.viewmodel
+
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.vinyl.app.pojo.Album
+import com.vinyl.app.pojo.Musician
+import com.vinyl.app.retrofit.RetrofitInstance
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+
+class AlbumViewModel(): ViewModel() {
+
+    private var albumDetailLiveData = MutableLiveData<Album>()
+
+    fun getAlbum(id: String){
+
+        RetrofitInstance.api.getAlbum(id).enqueue(object : Callback<Album> {
+            override fun onResponse(call: Call<Album>, response: Response<Album>) {
+                if(response.body() != null)
+                {
+                    val album : Album = response.body()!!
+                    albumDetailLiveData.value = album
+                }else
+                {
+                    return
+                }
+            }
+
+            override fun onFailure(call: Call<Album>, t: Throwable) {
+                Log.d("AlbumDetailFragment", t.message.toString())
+            }
+        })
+    }
+
+    fun observeAlbumLiveData(): LiveData<Album> {
+        return albumDetailLiveData
+    }
+}

--- a/app/src/main/res/layout/activity_album_detail.xml
+++ b/app/src/main/res/layout/activity_album_detail.xml
@@ -2,9 +2,15 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/main"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".activities.AlbumDetailActivity">
+    android:layout_height="match_parent">
 
+    <FrameLayout
+        android:id="@+id/fragment_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_album_detail.xml
+++ b/app/src/main/res/layout/fragment_album_detail.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp">
+
+    <ImageView
+        android:id="@+id/albumCover"
+        android:layout_width="200dp"
+        android:layout_height="200dp"
+        android:layout_marginTop="16dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        tools:src="@tools:sample/avatars" />
+
+    <TextView
+        android:id="@+id/albumName"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        android:layout_marginTop="16dp"
+        app:layout_constraintTop_toBottomOf="@id/albumCover"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        tools:text="Album Name" />
+
+    <TextView
+        android:id="@+id/albumGenre"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="16sp"
+        app:layout_constraintTop_toBottomOf="@id/albumName"
+        app:layout_constraintStart_toStartOf="parent"
+        tools:text="Genre" />
+
+    <TextView
+        android:id="@+id/albumDescription"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:textSize="14sp"
+        app:layout_constraintTop_toBottomOf="@id/albumGenre"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        tools:text="Description" />
+
+    <LinearLayout
+        android:id="@+id/tracksLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintTop_toBottomOf="@id/albumDescription"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/track_item.xml
+++ b/app/src/main/res/layout/track_item.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/trackName"
+        android:layout_width="0dp"
+        android:layout_weight="1"
+        android:layout_height="wrap_content"
+        android:textSize="14sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/trackDuration"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="14sp" />
+
+</LinearLayout>


### PR DESCRIPTION
This pull request adds the functionality to display the details of an album in the Vinyl app. It includes the necessary changes to the codebase, such as adding the `Track` data class, updating the `VinylApi` interface to include the `getAlbum` method, and creating the `AlbumViewModel` class. Additionally, it includes changes to the layout files and the `AlbumDetailActivity` class to handle the display of the album details.